### PR TITLE
Separate login and signup, add routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "hacktoberfest-tracking",
       "version": "0.0.0",
       "dependencies": {
-        "@supabase/supabase-js": "^2.0.0-rc.10"
+        "@supabase/supabase-js": "^2.0.0-rc.10",
+        "svelte-routing": "^1.6.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^1.0.2",
@@ -369,6 +370,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/dedent-js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
+      "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ=="
     },
     "node_modules/deepmerge": {
       "version": "4.2.2",
@@ -1015,6 +1021,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.26.3",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.3.tgz",
@@ -1120,6 +1134,15 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -1177,6 +1200,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-is-absolute": {
@@ -1436,7 +1468,6 @@
       "version": "3.50.1",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.50.1.tgz",
       "integrity": "sha512-bS4odcsdj5D5jEg6riZuMg5NKelzPtmsCbD9RG+8umU03TeNkdWnP6pqbCm0s8UQNBkqk29w/Bdubn3C+HWSwA==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -1550,6 +1581,30 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/svelte-routing": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/svelte-routing/-/svelte-routing-1.6.0.tgz",
+      "integrity": "sha512-+DbrSGttLA6lan7oWFz1MjyGabdn3tPRqn8Osyc471ut2UgCrzM5x1qViNMc2gahOP6fKbKK1aNtZMJEQP2vHQ==",
+      "dependencies": {
+        "svelte2tsx": "^0.1.157"
+      },
+      "peerDependencies": {
+        "svelte": "^3.20.x"
+      }
+    },
+    "node_modules/svelte2tsx": {
+      "version": "0.1.193",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.1.193.tgz",
+      "integrity": "sha512-vzy4YQNYDnoqp2iZPnJy7kpPAY6y121L0HKrSBjU/IWW7DQ6T7RMJed2VVHFmVYm0zAGYMDl9urPc6R4DDUyhg==",
+      "dependencies": {
+        "dedent-js": "^1.0.1",
+        "pascal-case": "^3.1.1"
+      },
+      "peerDependencies": {
+        "svelte": "^3.24",
+        "typescript": "^4.1.2"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1570,8 +1625,7 @@
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/type": {
       "version": "1.2.0",
@@ -1590,7 +1644,6 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1984,6 +2037,11 @@
       "requires": {
         "ms": "2.1.2"
       }
+    },
+    "dedent-js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
+      "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ=="
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -2386,6 +2444,14 @@
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true
     },
+    "lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
     "magic-string": {
       "version": "0.26.3",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.3.tgz",
@@ -2464,6 +2530,15 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
+    "no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "requires": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -2499,6 +2574,15 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
+      }
+    },
+    "pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "path-is-absolute": {
@@ -2664,8 +2748,7 @@
     "svelte": {
       "version": "3.50.1",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.50.1.tgz",
-      "integrity": "sha512-bS4odcsdj5D5jEg6riZuMg5NKelzPtmsCbD9RG+8umU03TeNkdWnP6pqbCm0s8UQNBkqk29w/Bdubn3C+HWSwA==",
-      "dev": true
+      "integrity": "sha512-bS4odcsdj5D5jEg6riZuMg5NKelzPtmsCbD9RG+8umU03TeNkdWnP6pqbCm0s8UQNBkqk29w/Bdubn3C+HWSwA=="
     },
     "svelte-check": {
       "version": "2.9.0",
@@ -2715,6 +2798,23 @@
         }
       }
     },
+    "svelte-routing": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/svelte-routing/-/svelte-routing-1.6.0.tgz",
+      "integrity": "sha512-+DbrSGttLA6lan7oWFz1MjyGabdn3tPRqn8Osyc471ut2UgCrzM5x1qViNMc2gahOP6fKbKK1aNtZMJEQP2vHQ==",
+      "requires": {
+        "svelte2tsx": "^0.1.157"
+      }
+    },
+    "svelte2tsx": {
+      "version": "0.1.193",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.1.193.tgz",
+      "integrity": "sha512-vzy4YQNYDnoqp2iZPnJy7kpPAY6y121L0HKrSBjU/IWW7DQ6T7RMJed2VVHFmVYm0zAGYMDl9urPc6R4DDUyhg==",
+      "requires": {
+        "dedent-js": "^1.0.1",
+        "pascal-case": "^3.1.1"
+      }
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2732,8 +2832,7 @@
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "type": {
       "version": "1.2.0",
@@ -2751,8 +2850,7 @@
     "typescript": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
-      "dev": true
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=="
     },
     "utf-8-validate": {
       "version": "5.0.9",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "vite": "^3.1.0"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.0.0-rc.10"
+    "@supabase/supabase-js": "^2.0.0-rc.10",
+    "svelte-routing": "^1.6.0"
   }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,6 +6,8 @@
   import Auth from './lib/Auth.svelte'
   import Dashboard from './lib/Dashboard.svelte'
   import { title } from "./stores/title.js";
+  import { Router, Route } from 'svelte-routing';
+  import Signup from './lib/Signup.svelte'
 
   title.clear()
   let session: AuthSession
@@ -19,17 +21,24 @@
       session = _session
     })
   })
+
+  export let url = "";
 </script>
 
 <svelte:head>
 	<title>{$title}</title>
 </svelte:head>
 
-<main class="container" style="padding: 50px 0 100px 0">
-  {#if !session}
-    <Auth />
-  {:else}
-    <Account {session} />
-    <Dashboard />
-  {/if}
-</main>
+<Router url={url}>
+  <main class="container" style="padding: 50px 0 100px 0">
+    {#if !session}
+      <Route path="/"><Auth /></Route>
+      <Route path="/signup"><Signup /></Route>
+    {:else}
+      <Route path="/">
+        <Account {session} />
+        <Dashboard />
+      </Route>
+    {/if}
+  </main>
+</Router>

--- a/src/lib/Auth.svelte
+++ b/src/lib/Auth.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { supabase } from '../supabaseClient'
   import { title } from "../stores/title.js";
+  import { link } from "svelte-routing";
 
 	title.set('Login');
 
@@ -64,6 +65,6 @@
       </div>
     </form>
 
-    <p class="description">Don't have an account? Sign up <a href="/signup">here</a>.</p>
+    <p class="description">Don't have an account? Sign up <a href="/signup" use:link>here</a>.</p>
   </div>
 </div>

--- a/src/lib/Auth.svelte
+++ b/src/lib/Auth.svelte
@@ -5,11 +5,8 @@
 	title.set('Login');
 
   let loadingSignIn: boolean = false
-  let loadingSignUp: boolean = false
   let signInEmail: string = ''
   let signInPassword: string = ''
-  let signUpEmail: string = ''
-  let signUpPassword: string = ''
 
   const handleSignIn = async () => {
     try {
@@ -26,31 +23,6 @@
       console.error(error)
     } finally {
       loadingSignIn = false
-    }
-  }
-
-  const handleSignUp = async () => {
-    try {
-      loadingSignUp = true
-
-      const { data, error } = await supabase.auth.signUp({
-        email: signUpEmail,
-        password: signUpPassword,
-        options: {
-          emailRedirectTo: import.meta.env.VITE_REDIRECT_EMAIL,
-        },
-      })
-
-      if (error) throw error
-
-      console.log(`Signed up user: ${JSON.stringify(data, undefined, 2)}`)
-      alert(
-        `Almost there! Please confirm your email address by following the link that has been sent to ${data.user.email}.`
-      )
-    } catch (error) {
-      console.error(error)
-    } finally {
-      loadingSignUp = false
     }
   }
 </script>
@@ -92,38 +64,6 @@
       </div>
     </form>
 
-    <p class="description">Don't have an account? Sign up here.</p>
-    <form class="form-widget" on:submit|preventDefault={handleSignUp}>
-      <div>
-        <label for="email">Signup Email</label>
-        <input
-          id="email"
-          class="inputField"
-          type="email"
-          placeholder="Your email"
-          bind:value={signUpEmail}
-        />
-      </div>
-      <div>
-        <label for="password">Create a Password</label>
-        <input
-          id="password"
-          class="inputField"
-          type="password"
-          placeholder="Your password"
-          bind:value={signUpPassword}
-        />
-      </div>
-      <div>
-        <button
-          type="submit"
-          class="button block"
-          aria-live="polite"
-          disabled={loadingSignIn}
-        >
-          <span>{loadingSignUp ? 'Loading' : 'Complete Signup'}</span>
-        </button>
-      </div>
-    </form>
+    <p class="description">Don't have an account? Sign up <a href="/signup">here</a>.</p>
   </div>
 </div>

--- a/src/lib/Signup.svelte
+++ b/src/lib/Signup.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { supabase } from '../supabaseClient'
     import { title } from "../stores/title.js";
+    import { link } from "svelte-routing";
   
       title.set('Sign Up');
   
@@ -69,7 +70,7 @@
           </button>
         </div>
         <p class="description">
-            <a href="/">Back to Login</a>
+            <a href="/" use:link>Back to Login</a>
         </p>
       </form>
     </div>

--- a/src/lib/Signup.svelte
+++ b/src/lib/Signup.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+    import { supabase } from '../supabaseClient'
+    import { title } from "../stores/title.js";
+  
+      title.set('Sign Up');
+  
+    let loadingSignUp: boolean = false
+    let signUpEmail: string = ''
+    let signUpPassword: string = ''
+  
+    const handleSignUp = async () => {
+      try {
+        loadingSignUp = true
+  
+        const { data, error } = await supabase.auth.signUp({
+          email: signUpEmail,
+          password: signUpPassword,
+          options: {
+            emailRedirectTo: import.meta.env.VITE_REDIRECT_EMAIL,
+          },
+        })
+  
+        if (error) throw error
+  
+        console.log(`Signed up user: ${JSON.stringify(data, undefined, 2)}`)
+        alert(
+          `Almost there! Please confirm your email address by following the link that has been sent to ${data.user.email}.`
+        )
+      } catch (error) {
+        console.error(error)
+      } finally {
+        loadingSignUp = false
+      }
+    }
+  </script>
+  
+  <div class="row flex-center flex">
+    <div class="col-6 form-widget" aria-live="polite">
+      <h1 class="header">Hacktoberfest Tracker</h1>
+      <p class="description">Enter your desired credentials to sign up</p>
+      <form class="form-widget" on:submit|preventDefault={handleSignUp}>
+        <div>
+          <label for="email">Signup Email</label>
+          <input
+            id="email"
+            class="inputField"
+            type="email"
+            placeholder="Your email"
+            bind:value={signUpEmail}
+          />
+        </div>
+        <div>
+          <label for="password">Create a Password</label>
+          <input
+            id="password"
+            class="inputField"
+            type="password"
+            placeholder="Your password"
+            bind:value={signUpPassword}
+          />
+        </div>
+        <div>
+          <button
+            type="submit"
+            class="button block"
+            aria-live="polite"
+          >
+            <span>{loadingSignUp ? 'Loading' : 'Complete Signup'}</span>
+          </button>
+        </div>
+        <p class="description">
+            <a href="/">Back to Login</a>
+        </p>
+      </form>
+    </div>
+  </div>
+  


### PR DESCRIPTION
Split the signup portion of the Auth page into its own page. Add svelte-routing and set up routes for the two pages. Add links back and forth.

![image](https://user-images.githubusercontent.com/19156328/195962766-ed4a87e4-4a0e-4018-9e3f-5f9112d80322.png)

![image](https://user-images.githubusercontent.com/19156328/195962778-0b58f083-f79a-4835-b150-eeb957231cdb.png)

Closes #6 
