### PR TITLE
Feature/add groups

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import { title } from './stores/title.js'
   import { Router, Route } from 'svelte-routing'
   import Signup from './lib/Signup.svelte'
+  import Groups from './lib/Groups.svelte'
 
   title.clear()
   let session: AuthSession
@@ -39,6 +40,7 @@
         <Account {session} />
         <Dashboard {session} />
       </Route>
+      <Route path="/groups"><Groups {session} /></Route>
     {/if}
   </main>
 </Router>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -5,8 +5,8 @@
   import Account from './lib/Account.svelte'
   import Auth from './lib/Auth.svelte'
   import Dashboard from './lib/Dashboard.svelte'
-  import { title } from "./stores/title.js";
-  import { Router, Route } from 'svelte-routing';
+  import { title } from './stores/title.js'
+  import { Router, Route } from 'svelte-routing'
   import Signup from './lib/Signup.svelte'
 
   title.clear()
@@ -22,14 +22,14 @@
     })
   })
 
-  export let url = "";
+  export let url = ''
 </script>
 
 <svelte:head>
-	<title>{$title}</title>
+  <title>{$title}</title>
 </svelte:head>
 
-<Router url={url}>
+<Router {url}>
   <main class="container" style="padding: 50px 0 100px 0">
     {#if !session}
       <Route path="/"><Auth /></Route>
@@ -37,7 +37,7 @@
     {:else}
       <Route path="/">
         <Account {session} />
-        <Dashboard />
+        <Dashboard {session} />
       </Route>
     {/if}
   </main>

--- a/src/lib/Dashboard.svelte
+++ b/src/lib/Dashboard.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte'
   import { supabase } from '../supabaseClient'
   import { title } from '../stores/title.js'
+  import { link } from 'svelte-routing'
 
   title.set('Dashboard')
   import type { AuthSession } from '@supabase/supabase-js'
@@ -93,6 +94,14 @@
     </select>
   </header>
 
+  {#if !userGroups.length}
+    <p>
+      You are not a member of any groups. <a href="/groups" use:link
+        >Join a group.</a
+      >
+    </p>
+  {/if}
+
   <dl class="profiles">
     {#each profiles as profile}
       <dt class="profile-username">{profile.username}</dt>
@@ -102,6 +111,8 @@
       </dd>
     {/each}
   </dl>
+
+  <p><a href="/groups" use:link>See all groups.</a></p>
 </section>
 
 <style>

--- a/src/lib/Dashboard.svelte
+++ b/src/lib/Dashboard.svelte
@@ -31,7 +31,7 @@
         `
           id,
           name,
-          group_profile (
+          group_profile!inner (
             id
           )
         `
@@ -47,6 +47,7 @@
   const getGroupProfiles = async () => {
     try {
       loading = true
+      if (!selectedGroup) return
 
       const { data: groupProfiles, error: profilesError } = await supabase
         .from('profiles')
@@ -78,29 +79,35 @@
   }
 
   const handleGroupChange = (event) => {
+    let currGroup = selectedGroup
     selectedGroup = userGroups.find(
       (group) => group.id === parseInt(event.target.value)
     )
+
+    // Re-render list of profiles when group changes
+    if (selectedGroup.id !== currGroup.id) {
+      getGroupProfiles()
+    }
   }
 </script>
 
 <section class="dashboard">
   <header>
     <h1>{selectedGroup ? selectedGroup.name : 'Your'} Dashboard</h1>
-    <select name="groupSelect" id="groupSelect" on:change={handleGroupChange}>
-      {#each userGroups as group}
-        <option value={group.id}>{group.name}</option>
-      {/each}
-    </select>
+    {#if userGroups.length}
+      <select name="groupSelect" id="groupSelect" on:change={handleGroupChange}>
+        {#each userGroups as group}
+          <option value={group.id}>{group.name}</option>
+        {/each}
+      </select>
+    {:else}
+      <p>
+        You are not a member of any groups. <a href="/groups" use:link
+          >Join a group.</a
+        >
+      </p>
+    {/if}
   </header>
-
-  {#if !userGroups.length}
-    <p>
-      You are not a member of any groups. <a href="/groups" use:link
-        >Join a group.</a
-      >
-    </p>
-  {/if}
 
   <dl class="profiles">
     {#each profiles as profile}
@@ -118,6 +125,7 @@
 <style>
   header {
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-evenly;
     align-items: center;
   }

--- a/src/lib/Groups.svelte
+++ b/src/lib/Groups.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  import { link } from 'svelte-routing'
+  import { onMount } from 'svelte'
+  import { supabase } from '../supabaseClient'
+  import type { AuthSession } from '@supabase/supabase-js'
+  import { title } from '../stores/title.js'
+
+  title.set('Groups')
+  let allGroups = []
+  export let session: AuthSession
+  const { user } = session
+
+  onMount(() => {
+    getAllGroups()
+  })
+
+  const getAllGroups = async () => {
+    const { data: groupsData, error: groupsError } = await supabase
+      .from('groups')
+      .select(
+        `
+          id,
+          name,
+          group_profile (
+            id
+          )
+        `
+      )
+      .eq('group_profile.profile_id', user.id)
+
+    if (groupsData) {
+      allGroups = groupsData
+    }
+  }
+
+  const handleClick = (event) => {
+    joinGroup(parseInt(event.target.dataset.groupId))
+  }
+
+  const joinGroup = async (groupId: number) => {
+    try {
+      let { error, status } = await supabase
+        .from('group_profile')
+        .insert({ group_id: groupId, profile_id: user.id })
+
+      if (status === 201) {
+        alert('You have successfully joined the group.')
+      }
+
+      if (error) throw error
+    } catch (error) {
+      console.log(error)
+      alert('There was an error joining this group.')
+    }
+  }
+</script>
+
+<section class="groups">
+  <h1>Groups</h1>
+
+  <dl class="groups-list">
+    {#each allGroups as group}
+      <dd class="group-name">
+        {group.name}<button data-group-id={group.id} on:click={handleClick}
+          >Join</button
+        >
+      </dd>
+    {/each}
+  </dl>
+
+  <a href="/" use:link>Back to Dashboard</a>
+</section>
+
+<style>
+  .groups {
+    width: 50%;
+    margin: 0 auto;
+  }
+
+  dd {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+</style>

--- a/src/lib/Groups.svelte
+++ b/src/lib/Groups.svelte
@@ -6,30 +6,53 @@
   import { title } from '../stores/title.js'
 
   title.set('Groups')
-  let allGroups = []
   export let session: AuthSession
   const { user } = session
 
+  let allGroups = []
+  let userGroups = []
+
   onMount(() => {
-    getAllGroups()
+    getGroupsData()
   })
 
-  const getAllGroups = async () => {
+  const getGroupsData = async () => {
+    await getJoinedGroups()
+    await getUnjoinedGroups()
+  }
+
+  const getUnjoinedGroups = async () => {
     const { data: groupsData, error: groupsError } = await supabase
       .from('groups')
       .select(
         `
           id,
+          name
+        `
+      )
+      .not('id', 'in', `(${userGroups.map((group) => group.id)})`)
+
+    if (groupsData) {
+      allGroups = groupsData
+    }
+  }
+
+  const getJoinedGroups = async () => {
+    const { data: groupData, error: groupError } = await supabase
+      .from('groups')
+      .select(
+        `
+          id,
           name,
-          group_profile (
+          group_profile!inner (
             id
           )
         `
       )
       .eq('group_profile.profile_id', user.id)
 
-    if (groupsData) {
-      allGroups = groupsData
+    if (groupData) {
+      userGroups = groupData
     }
   }
 
@@ -45,6 +68,9 @@
 
       if (status === 201) {
         alert('You have successfully joined the group.')
+
+        // Re-render list of groups to remove group just joined
+        getGroupsData()
       }
 
       if (error) throw error
@@ -57,6 +83,10 @@
 
 <section class="groups">
   <h1>Groups</h1>
+
+  {#if !allGroups.length}
+    <p>There are no groups to show.</p>
+  {/if}
 
   <dl class="groups-list">
     {#each allGroups as group}


### PR DESCRIPTION
Closes #22 

Probably too much for one PR, but I needed to flesh out a MVP for groups. I made some changes to the database that aren't shown here, but that can be seen in Supabase if desired

How it works:
- A user's dashboard will only show profiles from the currently selected group
- Users can only select groups that they are a member of
- Users can join groups from the new groups page

Next steps:
- Allow users to create new groups and to leave groups
- Set up some mechanism for group "admins" and "invitations" so that a user can request to join a group and has to be approved by an admin before joining

Other misc TODOs:
- This code is not very DRY -> perhaps the logged in `user` object and their list of groups should either be defined in `App.svelte` or placed in a store
- The delay while re-rendering after a state change should be handled better. Right now, there are "flickers" because I didn't handle the loading state very gracefully

---

# Testing

- Log into the site, the dashboard will probably be empty after this change
- Go to the groups page and select a group to join
- Go back to dashboard, verify that profiles are now shown in the dashboard